### PR TITLE
Add drag-and-drop stage updates and removal to GUI

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,37 +1,127 @@
 import tkinter as tk
-from models import Album
-from storage import load_db, save_db, generate_id, upsert_album
+from models import Album, Stage
+from storage import (
+    load_db,
+    save_db,
+    generate_id,
+    upsert_album,
+    remove_album,
+    find_album,
+)
 from utils.time import now_iso
 
 DB_PATH = "data/database.json"
+
 
 class TrackerGUI:
     def __init__(self, master: tk.Tk) -> None:
         self.master = master
         master.title("Album Review Tracker")
 
-        self.listbox = tk.Listbox(master, width=50)
-        self.listbox.pack(fill=tk.BOTH, expand=True)
+        self.drag_data = None
+        self.listboxes: dict[str, tk.Listbox] = {}
+
+        board = tk.Frame(master)
+        board.pack(fill=tk.BOTH, expand=True)
+
+        for stage in Stage:
+            col = tk.Frame(board)
+            col.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+            tk.Label(col, text=stage.value).pack()
+            lb = tk.Listbox(col, width=25)
+            lb.pack(fill=tk.BOTH, expand=True)
+            lb.stage = stage  # type: ignore[attr-defined]
+            self.listboxes[stage.value] = lb
+            self._make_draggable(lb)
 
         btn_frame = tk.Frame(master)
         btn_frame.pack(fill=tk.X)
         tk.Button(btn_frame, text="Refresh", command=self.refresh).pack(side=tk.LEFT)
         tk.Button(btn_frame, text="Add Album", command=self.open_add_dialog).pack(side=tk.LEFT)
+        tk.Button(btn_frame, text="Remove", command=self.remove_selected).pack(side=tk.LEFT)
 
         self.refresh()
 
+    def _make_draggable(self, lb: tk.Listbox) -> None:
+        lb.bind("<ButtonPress-1>", self.on_start_drag)
+        lb.bind("<B1-Motion>", self.on_drag)
+        lb.bind("<ButtonRelease-1>", self.on_drop)
+
+    def on_start_drag(self, event: tk.Event) -> None:
+        widget: tk.Listbox = event.widget  # type: ignore[assignment]
+        index = widget.nearest(event.y)
+        if index < 0:
+            return
+        self.drag_data = {
+            "widget": widget,
+            "index": index,
+            "item": widget.get(index),
+        }
+
+    def on_drag(self, event: tk.Event) -> None:
+        # No visual feedback needed for simple drag operation
+        pass
+
+    def on_drop(self, event: tk.Event) -> None:
+        if not self.drag_data:
+            return
+        target = event.widget.winfo_containing(event.x_root, event.y_root)
+        source_widget: tk.Listbox = self.drag_data["widget"]
+        item = self.drag_data["item"]
+        source_widget.delete(self.drag_data["index"])
+        if isinstance(target, tk.Listbox) and hasattr(target, "stage"):
+            target.insert(tk.END, item)
+            self.set_stage(item, target.stage)
+        else:
+            # revert if dropped outside
+            source_widget.insert(self.drag_data["index"], item)
+        self.drag_data = None
+
+    def set_stage(self, album_id: str, stage: Stage) -> None:
+        db = load_db(DB_PATH)
+        album = find_album(db, album_id)
+        if not album:
+            return
+        status = album.setdefault("status", {"stage": Stage.IDEATION.value, "history": []})
+        from_stage = status.get("stage", Stage.IDEATION.value)
+        status.setdefault("history", []).append(
+            {
+                "from_stage": from_stage,
+                "to_stage": stage.value,
+                "at": now_iso(),
+                "note": "",
+            }
+        )
+        status["stage"] = stage.value
+        save_db(DB_PATH, db)
+
     def refresh(self) -> None:
         db = load_db(DB_PATH)
-        self.listbox.delete(0, tk.END)
+        for lb in self.listboxes.values():
+            lb.delete(0, tk.END)
         for album in db.get("albums", []):
-            self.listbox.insert(tk.END, album["id"])
+            stage = album.get("status", {}).get("stage", Stage.IDEATION.value)
+            lb = self.listboxes.get(stage)
+            if lb:
+                lb.insert(tk.END, album["id"])
+
+    def remove_selected(self) -> None:
+        for lb in self.listboxes.values():
+            sel = lb.curselection()
+            if sel:
+                album_id = lb.get(sel[0])
+                db = load_db(DB_PATH)
+                if remove_album(db, album_id):
+                    save_db(DB_PATH, db)
+                self.refresh()
+                return
 
     def open_add_dialog(self) -> None:
         win = tk.Toplevel(self.master)
         win.title("Add Album")
 
         labels = ["Artist", "Album", "Release Date"]
-        vars = {}
+        vars: dict[str, tk.StringVar] = {}
         for i, label in enumerate(labels):
             tk.Label(win, text=label).grid(row=i, column=0, sticky=tk.W)
             var = tk.StringVar()

--- a/storage.py
+++ b/storage.py
@@ -55,6 +55,17 @@ def upsert_album(db: Dict, album_dict: Dict) -> None:
         db["albums"].append(album_dict)
 
 
+def remove_album(db: Dict, album_id: str) -> bool:
+    """Remove album with matching id from database.
+
+    Returns True if removed, False if not found."""
+    album = find_album(db, album_id)
+    if album:
+        db["albums"].remove(album)
+        return True
+    return False
+
+
 def snapshot(db_path: str) -> Path:
     db = load_db(db_path)
     snap_dir = Path(db_path).parent / "snapshots"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,7 +4,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import json
 from pathlib import Path
 
-from storage import generate_id, load_db, save_db, find_album, upsert_album
+from storage import generate_id, load_db, save_db, find_album, upsert_album, remove_album
 
 
 def test_generate_id_slug():
@@ -21,3 +21,13 @@ def test_load_save(tmp_path):
     save_db(str(db_path), db)
     db2 = load_db(str(db_path))
     assert find_album(db2, "1")
+
+
+def test_remove_album(tmp_path):
+    db_path = tmp_path / "db.json"
+    db = load_db(str(db_path))
+    album = {"id": "1", "artist": "A", "album": "B"}
+    upsert_album(db, album)
+    removed = remove_album(db, "1")
+    assert removed
+    assert find_album(db, "1") is None


### PR DESCRIPTION
## Summary
- Allow dragging albums between stage columns to update production status
- Add remove button to delete selected albums
- Support album removal in storage with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a776f5893c8330915447bc2615f99b